### PR TITLE
Add goreleaser to build and release dlv binaries

### DIFF
--- a/.github/workflows/release-go.yaml
+++ b/.github/workflows/release-go.yaml
@@ -1,0 +1,40 @@
+name: goreleaser
+
+on:
+  push:
+    # run only against tags
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+  # packages: write
+  # issues: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      -
+        name: Fetch all tags
+        run: git fetch --force --tags
+      -
+        name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.18
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          # either 'goreleaser' (default) or 'goreleaser-pro'
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ localtests
 *.iml
 .teamcity/target
 .vscode
+
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,31 @@
+# This is an example .goreleaser.yml file with some sensible defaults.
+# Make sure to check the documentation at https://goreleaser.com
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+builds:
+  - 
+    main: ./cmd/dlv
+    binary: dlv
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+archives:
+  - id: github
+    format: binary
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'

--- a/README.md
+++ b/README.md
@@ -21,3 +21,16 @@ The GitHub issue tracker is for **bugs** only. Please use the [developer mailing
   - [How to write a Delve client](Documentation/api/ClientHowto.md)
 
 Delve is a debugger for the Go programming language. The goal of the project is to provide a simple, full featured debugging tool for Go. Delve should be easy to invoke and easy to use. Chances are if you're using a debugger, things aren't going your way. With that in mind, Delve should stay out of your way as much as possible.
+
+## Releases
+
+This uses (GoReleaser](https://goreleaser.com) to build and release go binaries. There is a GitHub Actions workflow configured to run this on any new tags pushed. In order to create a new release, from the master branch:
+
+```
+git tag vx.x.x e.g. v1.0.0
+git push --tags
+```
+
+This should trigger the workflow to automatically create a new release. Once it has run, you should see a new release at https://github.com/99designs/ior/releases. Currently GoReleaser is configured to autogenerate a changelog based on commits.
+
+The configuration for GoReleaser is in [.goreleaser.yaml](./.goreleaser.yaml). This specifies what operating systems and architectures to build for along with any other customization we want. You can read more about what can be configured here: https://goreleaser.com/customization/


### PR DESCRIPTION
Follows a very similar pattern to https://github.com/99designs/ior/pull/1 in order to release pre-built binaries to be used in multi-arch Docker builds.

On top of default settings, the build configuration had to include a path to `cmd/dlv/main.go` and specify the name of the binary to be `dlv` to match how it is exported when using `go install` 